### PR TITLE
Attachments now open in a new tab.

### DIFF
--- a/app/views/addresses/index.html.erb
+++ b/app/views/addresses/index.html.erb
@@ -225,7 +225,7 @@
   <a href="#" class="attachments" data-matter-id="{{matterId}}">Attachments ({{attachmentCount}}) <span class="fa fa-caret-down"></span></a>
   <ul class="attachments">
     {{#attachments}}
-      <li><a href="{{link}}">{{name}}</a></li>
+      <li><a target="_blank" href="{{link}}">{{name}}</a></li>
     {{/attachments}}
   </ul>
 </script>


### PR DESCRIPTION
Added target="_blank" attribute to the attachment anchor tag template. On documents that the browser doesn't support natively (like .docx) it will open a blank tab and then prompt for a download. The blank tab remains open after downloading, but the state of MuniciPal doesn't change.

Does this solve the problem?
