### PR TITLE
Fix council member jump

### DIFF
--- a/app/assets/javascripts/mesa.js
+++ b/app/assets/javascripts/mesa.js
@@ -2,12 +2,12 @@
 // code specific to the mesa app
 
 // show just the card that is associated with the tab that was clicked
-function toggleCards() {
+function toggleCards(event) {
+    event.preventDefault();
 
     // if the currently selected card was clicked, nothing to do; ignore click.
     if ($(this).parent().hasClass('pure-menu-selected')) {
         console.log('ignoring useless click');
-        event.preventDefault();
         return;
     }
 
@@ -17,8 +17,6 @@ function toggleCards() {
 
     $(this).parent().parent().find('.pure-menu-selected').removeClass('pure-menu-selected');
     $(this).parent().addClass('pure-menu-selected');
-
-	event.preventDefault();
 }
 
 $('#controls-bio').click(toggleCards);


### PR DESCRIPTION
In Firefox, the event object is not global and must be passed (event.preventDefault() wasn't working).

Fixes #7.
