### PR TITLE
Fix facebook box

### DIFF
--- a/app/assets/stylesheets/mesa.css.scss
+++ b/app/assets/stylesheets/mesa.css.scss
@@ -376,6 +376,8 @@ div#disqus_thread {
 /* more tips: http://stackoverflow.com/questions/10656038/how-to-make-the-facebook-like-box-responsive */
 .fb-like-box, .fb-like-box span, .fb-like-box span iframe[style] {
   width: 100% !important;
+  height: 400px !important;
+  overflow: visible !important;
 }
 
 #map {

--- a/app/views/addresses/index.html.erb
+++ b/app/views/addresses/index.html.erb
@@ -90,22 +90,22 @@
 
           <div class="card" id="facebook-card">
             <div class="fb-widget" id="facebook-1">
-              <div class="fb-like-box" data-href="https://www.facebook.com/CouncilmemberDaveRichins" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="true" data-header="false" data-stream="true" data-show-border="false"></div>
+              <div class="fb-like-box" data-href="https://www.facebook.com/CouncilmemberDaveRichins" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="false" data-header="false" data-stream="true" data-show-border="false"></div>
             </div>
             <div class="fb-widget" id="facebook-2">
-              <div class="fb-like-box" data-href="https://www.facebook.com/CouncilmemberBenelli" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="true" data-header="false" data-stream="true" data-show-border="false"></div>
+              <div class="fb-like-box" data-href="https://www.facebook.com/CouncilmemberBenelli" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="false" data-header="false" data-stream="true" data-show-border="false"></div>
             </div>
             <div class="fb-widget" id="facebook-3">
-              <div class="fb-like-box" data-href="https://www.facebook.com/councilmember.kavanaugh" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="true" data-header="false" data-stream="true" data-show-border="false"></div>
+              <div class="fb-like-box" data-href="https://www.facebook.com/councilmember.kavanaugh" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="false" data-header="false" data-stream="true" data-show-border="false"></div>
             </div>
             <div class="fb-widget" id="facebook-4">
-              <div class="fb-like-box" data-href="https://www.facebook.com/CouncilmemberChrisGlover" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="true" data-header="false" data-stream="true" data-show-border="false"></div>
+              <div class="fb-like-box" data-href="https://www.facebook.com/CouncilmemberChrisGlover" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="false" data-header="false" data-stream="true" data-show-border="false"></div>
             </div>
             <div class="fb-widget" id="facebook-5">
-              <div class="fb-like-box" data-href="https://www.facebook.com/CouncilmemberDavidLuna" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="true" data-header="false" data-stream="true" data-show-border="false"></div>
+              <div class="fb-like-box" data-href="https://www.facebook.com/CouncilmemberDavidLuna" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="false" data-header="false" data-stream="true" data-show-border="false"></div>
             </div>
             <div class="fb-widget" id="facebook-6">
-              <div class="fb-like-box" data-href="https://www.facebook.com/CouncilmemberScottSomers" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="true" data-header="false" data-stream="true" data-show-border="false"></div>
+              <div class="fb-like-box" data-href="https://www.facebook.com/CouncilmemberScottSomers" data-width="500" data-height="400" data-colorscheme="light" data-show-faces="false" data-header="false" data-stream="true" data-show-border="false"></div>
             </div>
           </div>
 


### PR DESCRIPTION
**What it solves:**
Visually, this solves the problem of the Facebook widget sometimes failing to display. It always loads, it's just sometimes set by Facebook at 0px height and width, as well as hiding the overflow. This is a "good enough" fix IMO with other stuff to do on such a short deadline.

**What it doesn't solve:**
There is a warning in the console that states `fb:like_box failed to resize in 45s` once for each feed. Some sleuthing in various places makes it seem like this entire issue is caused by the widget being loaded inside an element with the style `display: hidden`.

**Possible full fix to explore:**
If the Facebook widget is not rendered until the click that displays the tab it is contained within, I believe it would work and also stop throwing the warning. This would be similar to how the Disqus threads are being loaded on a click action.
