### PR TITLE
adds districts outline to home page

### DIFF
--- a/app/assets/javascripts/updatepage.js
+++ b/app/assets/javascripts/updatepage.js
@@ -90,9 +90,9 @@ function updatePage(ll) {
         districtLayer.setGeoJSON(geoJSON);
         districtLayer.setFilter(function() { return true; });
 
-        // HACK. this stuff should go in initializer on page load.
-        // todo : on page load, hit a URL that will return just the districts.
-        addDistrictsToMap(data.districts);
+        // // HACK. this stuff should go in initializer on page load.
+        // // todo : on page load, hit a URL that will return just the districts.
+        // addDistrictsToMap(data.districts);
 
         updatePageContent(data);
 

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -40,6 +40,8 @@ class AddressesController < ApplicationController
       end
     end
 
+    @districts = CouncilDistrict.getDistricts()
+
     @response = { :lat                    => @lat,
                   :lng                    => @lng,
                   :address                => @addr,

--- a/app/views/addresses/index.html.erb
+++ b/app/views/addresses/index.html.erb
@@ -137,3 +137,12 @@
 
 <%= javascript_include_tag "addresses", "data-turbolinks-track" => true %>
 
+<script>
+
+$(document).ready(function() {
+  districts = <%= raw @districts.to_json %>
+  addDistrictsToMap(districts);
+})
+
+</script>
+


### PR DESCRIPTION
Currently we show a basic map on the home page, and only after the user picks a location (by entering address and clicking submit button or by dragging the marker) do we show the districts. 

It seems like the district outlines would be somewhat useful on the map on the home page (mainly for staff or city councilmembers who know what district they're interested in). The outline is light enough that it shouldn't be distracting to people who don't know what the shapes represent. 
