### PR TITLE
Adds ability to get district items w/o address or lat/lng

### DIFF
--- a/app/assets/javascripts/process_url.js
+++ b/app/assets/javascripts/process_url.js
@@ -2,14 +2,18 @@ function processUrl() {
   var urlAddress = getUrlVar("address");
   var urlLat = getUrlVar("lat");
   var urlLong = getUrlVar("long");
+  var urlDistrict = getUrlVar("district");
   console.log("address: " + urlAddress);
   console.log("lat: " + urlLat);
-  console.log("lon" + urlLong);
+  console.log("lon: " + urlLong);
+  console.log("district: " + urlDistrict);
   if(urlAddress && urlAddress != '') {
     updatePage({'address': urlAddress});
     console.log("address is not empty");
   } else if (urlLat && urlLat != '' && urlLong && urlLong != '') {
     updatePage({'lat': urlLat, 'long': urlLong});
     console.log("lat and long are not empty");
+  } else if (urlDistrict && urlDistrict != '') {
+    updatePage({'district': urlDistrict});
   }
 }

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -8,6 +8,19 @@ class AddressesController < ApplicationController
     @in_district = false
     @lat = nil, @lng = nil, @address = nil
 
+    # district given
+    if not params[:district].blank?
+
+      # find lat/lon at center of polygon
+      @in_district = true
+      any_point = CouncilDistrict.point_in_district params[:district]
+      @lat = any_point["lat"]
+      @lng = any_point["lng"]
+
+      # find address at given lat/lon
+      @address = Geokit::Geocoders::MultiGeocoder.reverse_geocode "#{@lat}, #{@lng}"
+    end
+
     # address given; geocode to get lat/lon
     if not params[:address].blank?
       @address = Geokit::Geocoders::MultiGeocoder.geocode params[:address]

--- a/app/models/council_district.rb
+++ b/app/models/council_district.rb
@@ -32,5 +32,22 @@ class CouncilDistrict < ActiveRecord::Base
     return @districts_as_geojson;
   end
 
+  def self.point_in_district district
+    @point = ActiveRecord::Base.connection.select_one(
+        "WITH results as (
+          SELECT ST_Transform(
+            ST_SetSRID(
+              ST_PointOnSurface(geom),
+              #{COORD_SYS_AREA}
+            ),
+            #{COORD_SYS_REF}
+          ) as point from council_districts where id = #{district}
+        ) SELECT ST_X(point) as lng, ST_Y(point) as lat from results"
+    )
+
+    @point = @point.merge(@point) { |k,v| v.to_f } #string to float on all hash values
+    return @point
+  end
+
 
 end


### PR DESCRIPTION
By hitting the root controller with /?district=X you can find items for that district.

To make this work, if `district` param is supplied, we use the ST_PointOnSurface function from PostGIS (we use that instead of ST_Centroid because the centroid of a polygon isn't necessarily inside the polygon, while this function by does return a point on the surface, that is, inside the polygon). It seems to return a point well away from the edges too, which should make it clear which district the marker is inside.

After the point is returned, we grab the lat/lng for it and reverse geocode it. After that the code is no different than if someone had passed lat/lng or address as a url parameter.

This isn't hooked up to any UI elements on the frontend (I'll leave that to @ardouglass). So for now, just type the URL manually.
