### PR TITLE
Updated README with installation instructions based on test-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,21 +55,18 @@ The EPSG for this shapefile must be 4326.
 
 #### Notes on deploying to heroku:
 
-heroku create
-heroku config:set BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi.git
-heroku addons:add heroku-postgresql:standard-tengu
-heroku pg:info
-heroku pg:promote NAME_OF_DATABASE
-git push heroku master
-heroku run rake db:migrate
-heroku run bundle exec rake mesa_councils:load
-heroku run bundle exec rake legistar_events:load
-heroku run bundle exec rake legistar_event_items:load
-heroku run bundle exec rake legistar_event_items:load
-heroku run bundle exec rake legistar_event_items_districts:load
+        heroku create
+        heroku config:set BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi.git
+        heroku addons:add heroku-postgresql:standard-tengu
+        heroku pg:info
+        heroku pg:promote NAME_OF_DATABASE
+        git push heroku master
+        heroku run rake db:migrate
+        heroku run rake legistar_all:load
+        heroku run rake council_districts:load
 
 # Copyright
 
 Copyright (c) 2014 Code for America. BSD License.
-Based sa-zone, created by Amy Mok, Maya Benari, and David Leonard.
+Based on [sa-zone](https://github.com/codeforamerica/sa-zone), created by Amy Mok, Maya Benari, and David Leonard.
 Significantly modified by Peter Welte, Tom Buckley, Andrew Douglas, and Wendy Fong.


### PR DESCRIPTION
I’ve re-written some of the installation instructions to better reflect existing resources we have for Ruby and PostgreSQL, and to highlight a few gotchas I’ve encountered along the way while testing installation on Ubuntu 14.04 Linux.

I am unable to proceed past the final `bundle` step:

```
$ bundle exec rake council_districts:load

  CouncilDistrict Load (1.2ms)  SELECT "council_districts".* FROM "council_districts"
File contains 6 records
rake aborted!
RGeo::Error::RGeoError: GEOS is not available, but is required for correct interpretation of polygons in shapefiles.
/home/migurski/.rvm/gems/ruby-2.1.1/gems/rgeo-shapefile-0.2.3/lib/rgeo/shapefile/reader.rb:623:in `_read_polygon'
/home/migurski/.rvm/gems/ruby-2.1.1/gems/rgeo-shapefile-0.2.3/lib/rgeo/shapefile/reader.rb:453:in `_read_next_record'
/home/migurski/.rvm/gems/ruby-2.1.1/gems/rgeo-shapefile-0.2.3/lib/rgeo/shapefile/reader.rb:406:in `each'
/home/migurski/MuniciPal/lib/tasks/council_districts.rake:13:in `block (3 levels) in <top (required)>'
/home/migurski/.rvm/gems/ruby-2.1.1/gems/rgeo-shapefile-0.2.3/lib/rgeo/shapefile/reader.rb:207:in `open'
/home/migurski/MuniciPal/lib/tasks/council_districts.rake:11:in `block (2 levels) in <top (required)>'
/home/migurski/.rvm/gems/ruby-2.1.1/bin/ruby_executable_hooks:15:in `eval'
/home/migurski/.rvm/gems/ruby-2.1.1/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => council_districts:load
(See full trace by running task with --trace)
```
