### PR TITLE
Reorder top nav to match political order.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,6 @@
   </div>
     <ul>
       <li><a href="/mayor">Mayor</a></li>
-      <li><a href="/manager">City Manager</a></li>
       <li class="pure-dropdown">
         <a href="#">Districts<span class="arrow"></span></a>
         <ul class="pure-menu-children">
@@ -45,6 +44,7 @@
           <li><a href="/?district=all">Show All</a></li>
         </ul>
       </li>
+      <li><a href="/manager">City Manager</a></li>
     </ul>
 </div>
 


### PR DESCRIPTION
This just moves 'City Manager' menu item after [Councilmember] 'Districts'.
- Fixes #52 
