### PR TITLE
handle missing social accounts for people

### DIFF
--- a/app/assets/javascripts/application_onload.js
+++ b/app/assets/javascripts/application_onload.js
@@ -13,6 +13,9 @@ $(document).ready(function() {
 	twitterTemplate = $('#twitter-template').html();
 	Mustache.parse (twitterTemplate);
 
+	noTwitterTemplate = $('#no-twitter-template').html();
+	Mustache.parse (noTwitterTemplate);
+
 	legislationTemplate = $('#legislation-template').html();
 	Mustache.parse (legislationTemplate);  // optional, speeds up future uses
 

--- a/app/assets/javascripts/person.js
+++ b/app/assets/javascripts/person.js
@@ -62,7 +62,11 @@ Person.prototype.render = function(container) {
     $('#facebook-card').html(Mustache.render(noFacebookTemplate));
   }
 
-  $('#twitter-card').html(Mustache.render(twitterTemplate, who_view));
+  if (this.socialDetails('twitter')) {
+    $('#twitter-card').html(Mustache.render(twitterTemplate, who_view));
+  } else {
+    $('#twitter-card').html(Mustache.render(noTwitterTemplate));
+  }
 
 
   $('.person-title').empty().append(this.title()).removeClass("no-district").show(); // TODO remove no-district stuff

--- a/app/views/layouts/_mustache_templates.html.erb
+++ b/app/views/layouts/_mustache_templates.html.erb
@@ -14,6 +14,10 @@
   </div>
 </script>
 
+<script id="no-twitter-template" type="x-tmpl-mustache">
+  <p>This person has no known Twitter account.</p>
+</script>
+
 <script id="legislation-template" type="x-tmpl-mustache">
 
   <article class="legislation pure-g" id={{matterId}}>


### PR DESCRIPTION
- Not all people will have Facebook/Twitter pages.
- Instead of trying to render a non-existing page/tweets, 
- Before this, we tried to render things that didn't exist
- Now we just tell the user that the person they’re interested in has no Facebook or Twitter page, as the case may be.
- This fixes #51 (note that it keeps the tab for a consistent UI, but otherwise handles the situation more gracefully than previously). 
