### PR TITLE
fix null text bug: match any character, including newlines

### DIFF
--- a/app/assets/javascripts/legistar/legistar.js
+++ b/app/assets/javascripts/legistar/legistar.js
@@ -169,7 +169,7 @@ EventItem.summarize = function(text) {
 
     // regex looking for short_text worth of characters + whatever it takes to get to a whitespace
     // (we only want to break on whitespace, so we don't cut words in half)
-    var re = new RegExp('.{' + short_text + '}\\S*?\\s');
+    var re = new RegExp('^[\\s\\S]{' + short_text + '}\\S*?\\s');
 
     teaser = '<div class="teaser">' + p(text.match(re) + '&hellip;' + continueReading) + '</div>';
     body = '<div class="body">' + p(text) + '</div>';


### PR DESCRIPTION
- Start from the beginning of the text (regex start of line: ‘^’).
- The ‘.’ in regex matches any character excluding newlines.
- The character set of \s + \S matches any character including newlines.
- Before when excluded newlines, we were dropping some short sentences at the start of the text and only matching longer lines that didn’t have newlines in them. This fixes that.
- Fixes #37
