### PR TITLE
fetch districts with ajax GET for speediness

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -133,7 +133,7 @@ var convertESRItoGeoJSON = function (esriJSON) {
 // fetch districts, then add them to map
 function fetchDistricts() {
    $.ajax({
-    type: 'POST',
+    type: 'GET',
     crossDomain: true,
     url: config.map.districtsQueryESRIurl,
     dataType: 'json',


### PR DESCRIPTION
This fixes #123. 

‘POST requests are never cached’: http://blog.httpwatch.com/2009/08/07/ajax-caching-two-important-facts/

For users that have visited previously, we can speed loading by a factor of ten by switching from doing the AJAX request via POST to GET (which allows caching). You can see this by looking at Chrome’s dev console -> ‘network’ tab and observing a page load.

To reproduce / test:
1. Open Chrome's network tab
2. Click the 'disable cache' button
3. Load the homepage
4. Click the 'disable cache' button (enable the cache again)
5. Reload the page and observe the load time (note that regardless of POST/GET mode, it seems to be faster than on first page load anyway, but also GET is much faster than POST due to caching).

AJAX request with POST:
![screen shot 2014-11-13 at 9 32 11 am](https://cloud.githubusercontent.com/assets/1072292/5033287/700fcfa0-6b19-11e4-8b28-4c9401591f70.png)

improved with GET:
![screen shot 2014-11-13 at 9 36 54 am](https://cloud.githubusercontent.com/assets/1072292/5033277/5cbb718e-6b19-11e4-866d-ebbea9ef26e7.png)

My testing showed a factor of 10 improvement, from 4s to 460ms but that was also when emulating a slow network (EDGE 250Kbps with 300ms RTT).
