### PR TITLE
When user clicks district, move marker.

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -154,13 +154,15 @@ var highlightCurrentDistrict = function () {
     district.properties.fill = config.map.district_fill;
     districtLayer.setGeoJSON(district);
     districtLayer.setFilter(function() { return true; });
+    var center;
     if ((typeof app.data.lat === "undefined" || !app.data.lat) &&
         (typeof app.data.address === "undefined" || !app.data.address)) {
-      var center = districtLayer.getBounds().getCenter();
-      marker.setLatLng(center);
-      map.setView(center);
+      center = districtLayer.getBounds().getCenter();
+    } else {
+      center = L.latLng(app.data.lat, app.data.lng);
     }
-
+    marker.setLatLng(center).closePopup();
+    map.setView(center);
   }
 }
 


### PR DESCRIPTION
Fixes #125

This also ensures that the marker popup “Click and drag me!”) is
closed upon updating it’s location.
