### PR TITLE
Load resources securely so page displays w/o error over HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development, :test do
   gem 'byebug'
   gem 'rspec-rails', '2.14.2'
   gem 'shoulda-matchers', '2.6.1'
+  gem 'thin'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,9 +56,11 @@ GEM
       execjs
     coffee-script-source (1.8.0)
     columnize (0.8.9)
+    daemons (1.1.9)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
+    eventmachine (1.0.4)
     execjs (2.2.2)
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)
@@ -160,6 +162,10 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    thin (1.6.3)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0)
+      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -202,5 +208,6 @@ DEPENDENCIES
   sdoc
   selenium-webdriver (= 2.35.1)
   shoulda-matchers (= 2.6.1)
+  thin
   uglifier (= 2.5.0)
   unicorn

--- a/app/views/addresses/index.html.erb
+++ b/app/views/addresses/index.html.erb
@@ -50,7 +50,7 @@
 
 <%= render "layouts/mustache_templates" %>
 
-<%= javascript_include_tag "http://techieshark.github.io/council-info/people.js" %>
+<%= javascript_include_tag "https://techieshark.github.io/council-info/people.js" %>
 <%= javascript_include_tag "addresses", "data-turbolinks-track" => true %>
 
 <script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,13 +5,12 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.5.0/pure-min.css">
 
   <!--[if lte IE 8]>
-      <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.5.0/grids-responsive-old-ie-min.css">
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/g/pure@0.5.0(pure-min.css+grids-responsive-old-ie-min.css)">
   <![endif]-->
   <!--[if gt IE 8]><!-->
-      <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.5.0/grids-responsive-min.css">
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/g/pure@0.5.0(pure-min.css+grids-responsive-min.css)">
   <!--<![endif]-->
 
 


### PR DESCRIPTION
Fixes #135. 

Note that there is still [some Heroku configuration](https://devcenter.heroku.com/articles/ssl-endpoint) to get certificates (see [possible](https://devcenter.heroku.com/articles/ssl-certificate-dnsimple) [sources](https://www.startssl.com/)) set up for a custom domain (running on .herokuapp.com should work fine for testing though).

Also note, we're just getting resources via HTTPS instead of a [protocol-relative URL](http://www.paulirish.com/2010/the-protocol-relative-url/) as that is recommended and has no apparent performance hit.