### PR TITLE
Limit matters to those soon/recently

### DIFF
--- a/lib/tasks/legistar_matters.rake
+++ b/lib/tasks/legistar_matters.rake
@@ -3,8 +3,8 @@ require 'legistar'
 namespace :legistar_matters do
   desc "Load Legistar matters into database from REST API"
   task :load => :environment do
-    # DEBUG: filter items returned for quicker development cycles
-    filter = "?$filter=MatterIntroDate+ge+datetime'2014-09-01'+and+MatterIntroDate+lt+datetime'2015-01-01'"
+    # Limit the date range of data returned since we need only show things near to now.
+    filter = "?$filter=MatterIntroDate+ge+datetime'"+(Date.today - 120).to_s+"'+and+MatterIntroDate+lt+datetime'"+(Date.today + 120).to_s+"'"
     Legistar.initialize()
     Legistar.fetch_collection('Matters', filter, 'Matter', Matter)
   end


### PR DESCRIPTION
- the prev code used a hard code fixed date, which became stale
- this calculates date dynamically

- Fixes #150 

The following should be run after this pushing this code to heroku:

```
heroku run rake legistar_matters:drop 
heroku run rake legistar_matters:load 
heroku run rake legistar_attachments:drop
heroku run rake legistar_attachments:load
```

Alternatively you can run a complete refresh of the Legistar content: `heroku run rake legistar_all:refresh`.