### PR TITLE
trigger Facebook widget reload w/o page reload

### DIFF
--- a/app/assets/javascripts/updatepage.js
+++ b/app/assets/javascripts/updatepage.js
@@ -72,7 +72,7 @@ var app = app || {};
 
 app.maybeRenderFacebook = function() {
 
-  if ('renderedFacebook' in app) {
+  if (app.renderedFacebook) {
     // console.debug("Facebook widget already rendered; skipping re-render");
   } else if ((('FB' in window) && ('XFBML' in FB)) && ($('#facebook-card .fb-widget').length > 0))
     // console.debug("Facebook widget already rendered; skipping re-render");
@@ -118,6 +118,8 @@ function update_with_new( data ) {
   // console.debug("rendering page via update_with_new()");
 
   if (!data.event_items) { return; } // must be at root w/ no data yet
+
+  app.renderedFacebook = false; // try rerendering on page updates
 
   app.data = data;
 


### PR DESCRIPTION
Fixes #156

- note the diff on line 75: we’re checking for not just the 
existence of `renderedFacebook` but also checking that it 
is true

- and when we do an internal update (without a page refresh)
  we reset the flag to ensure we try to reload the widget