### PR TITLE
Make map show up on small screens too*.

### DIFF
--- a/app/assets/stylesheets/mesa.css.scss
+++ b/app/assets/stylesheets/mesa.css.scss
@@ -685,6 +685,14 @@ p.descript {
   }
 }
 
+// iPhone 2G-4S in portrait; see stephen.io/mediaqueries
+@media only screen and (min-device-width : 320px) and (max-device-width : 480px)
+{
+  #map {
+    height: 310px; /* small enough to grab outside the map when we need to scroll past it */
+  }
+}
+
 /*  Responsive helpers where Pure blew it  */
 
 // Above size

--- a/app/views/addresses/index.html.erb
+++ b/app/views/addresses/index.html.erb
@@ -28,7 +28,7 @@
   </div>
   <!-- END HEADER CONTAINER -->
 
-  <div class="pure-u-1 pure-u-lg-1-2 pure-u-md-2-5 hide-sm">
+  <div class="pure-u-1 pure-u-lg-1-2 pure-u-md-2-5">
     <div id="map"></div>
   </div>
 </div> <!-- end header/search grid -->


### PR DESCRIPTION
* while making the map a bit smaller on small screens so 
  scrolling should still be possible (otherwise, map captures
  the click & drag touch event and just pans the map, so we 
  leave enough space so the user can touch outside the map).

This 
- makes behavior consistent with desktops, and 
- fixes #158.