### PR TITLE
Fixes/169 fetch legistar

### DIFF
--- a/lib/legistar.rb
+++ b/lib/legistar.rb
@@ -35,7 +35,7 @@ module Legistar
     @@base_url = "http://webapi.legistar.com"
     # extras: any additional parameters that should be set on each object (optional)
     @@extras = nil
-    @@wait = 0.5 #seconds to wait between fetching
+    @@wait = 0.5 # seconds to wait between fetching
 
     @@connection = Faraday.new(url: @@base_url) do |conn|
       conn.headers["Accept"] = "text/json"
@@ -139,8 +139,8 @@ module Legistar
                               nesting_collection=nil)
 
     @@endpoint = endpoint # "EventItems"
-    @@prefix_to_strip = endpoint_prefix_to_strip #"EventItem"
-    @@endpoint_class = endpoint_class #EventItem
+    @@prefix_to_strip = endpoint_prefix_to_strip # "EventItem"
+    @@endpoint_class = endpoint_class # EventItem
 
     log_info("fetching from endpoint: #{endpoint} (nesting_endpoint: #{nesting_endpoint}), filter: #{endpoint_filter}, prefix: #{endpoint_prefix_to_strip}, class: #{endpoint_class}")
 
@@ -153,7 +153,9 @@ module Legistar
       # we want to keep a reference to the nesting object's id.
       # note that this is more important for Attachments, which don't
       # have an MatterId field, while EventItems do have an EventId.
-      @@extras = { nesting_class.to_s.underscore + "_id" => nesting_item.source_id}
+      @@extras = {
+        nesting_class.to_s.underscore + "_id" => nesting_item.source_id
+      }
 
       go_fetch()
     end
@@ -249,7 +251,8 @@ module Legistar
     # prepended to each.
     # We need to convert that into lines like: t.integer :source_id
     structure["results"].each do |field|
-      puts "t." + rubify_type(field["type"]) + " :" + rubify_name(field["name"], prefix_to_strip)
+      puts "t." + rubify_type(field["type"]) +
+           " :" + rubify_name(field["name"], prefix_to_strip)
     end
   end
 

--- a/lib/legistar.rb
+++ b/lib/legistar.rb
@@ -9,7 +9,7 @@ module Legistar
   class LegistarHTTPmismatch < StandardError
   end
 
-	module_function
+  module_function
 
   def http_response_mismatch(http_method, expected, got)
     # try to give the user somewhat human friendly responses
@@ -21,12 +21,12 @@ module Legistar
     LegistarHTTPmismatch.new(msg)
   end
 
-	# hack. This should go in a config file. TODO.
-	def city
-		"Mesa"
-	end
+  # hack. This should go in a config file. TODO.
+  def city
+    "Mesa"
+  end
 
-	# set up logging and Legistar base settings
+  # set up logging and Legistar base settings
   def initialize
     logfile = "log/fetch-legistar.log"
     @file_log = Logger.new(logfile)
@@ -37,16 +37,16 @@ module Legistar
     @@extras = nil
     @@wait = 0.5 #seconds to wait between fetching
 
-		@@connection = Faraday.new(url: @@base_url) do |conn|
-			conn.headers["Accept"] = "text/json"
-			conn.request :instrumentation
-			conn.response :json
+    @@connection = Faraday.new(url: @@base_url) do |conn|
+      conn.headers["Accept"] = "text/json"
+      conn.request :instrumentation
+      conn.response :json
       conn.adapter Faraday.default_adapter
       conn.request :retry, max: 5, interval: 0.05, interval: 0.05, interval_randomness: 0.5, backoff_factor: 2
-	  end
+    end
 
     @log.info("Connection opened to #{@@base_url} and logging to #{logfile}")
-	end
+  end
 
   # given the URL of one of the Legistar documentation pages,
   # return the documented structure of the endpoint in a format
@@ -119,35 +119,35 @@ module Legistar
     end
   end
 
-	# fetches items from an endpoint nested within a nesting_endpoint.
-	# example from Legistar API:
-		# /v1/{client}/Events/{id}/EventItems
-		# endpoint is "EventItems"
-		# endpoint_filter is nil
-		# endpoint_prefix_to_strip is "EventItem"
-		# endpoint_class is EventItem
-		# nesting_endpoint is "Events"
-		# nesting_class is Event
+  # fetches items from an endpoint nested within a nesting_endpoint.
+  # example from Legistar API:
+    # /v1/{client}/Events/{id}/EventItems
+    # endpoint is "EventItems"
+    # endpoint_filter is nil
+    # endpoint_prefix_to_strip is "EventItem"
+    # endpoint_class is EventItem
+    # nesting_endpoint is "Events"
+    # nesting_class is Event
   # By default, the endpoints within every item of nesting class will be fetched;
   # the set can be overridden by passing in nesting_collection though.
-	def fetch_nested_collection(endpoint,
-															endpoint_filter,
-															endpoint_prefix_to_strip,
-															endpoint_class,
-															nesting_endpoint,
-															nesting_class,
+  def fetch_nested_collection(endpoint,
+                              endpoint_filter,
+                              endpoint_prefix_to_strip,
+                              endpoint_class,
+                              nesting_endpoint,
+                              nesting_class,
                               nesting_collection=nil)
 
     @@endpoint = endpoint # "EventItems"
     @@prefix_to_strip = endpoint_prefix_to_strip #"EventItem"
-		@@endpoint_class = endpoint_class #EventItem
+    @@endpoint_class = endpoint_class #EventItem
 
     log_info("fetching from endpoint: #{endpoint} (nesting_endpoint: #{nesting_endpoint}), filter: #{endpoint_filter}, prefix: #{endpoint_prefix_to_strip}, class: #{endpoint_class}")
 
     nesting_collection ||= nesting_class.all
     nesting_collection.each do |nesting_item|
-    	# url = "/Events/#{event.source_id}/EventItems"
-		  @@url_path = "/v1/#{Legistar.city}/#{nesting_endpoint}/#{nesting_item.source_id}/#{endpoint}#{endpoint_filter}"
+      # url = "/Events/#{event.source_id}/EventItems"
+      @@url_path = "/v1/#{Legistar.city}/#{nesting_endpoint}/#{nesting_item.source_id}/#{endpoint}#{endpoint_filter}"
 
       # for nested items (like Attachments or EventItems),
       # we want to keep a reference to the nesting object's id.
@@ -161,24 +161,24 @@ module Legistar
 
 
 
-	# endpoint: which endpoint in the Legistar API to fetch
-	#          example: "events" for fetching from /v1/#{Legistar.city}/events
-	# endpoint_class: the Class of structure to create with the data retrieved from API
-	#          example: Event
-	def fetch_collection(endpoint,
+  # endpoint: which endpoint in the Legistar API to fetch
+  #          example: "events" for fetching from /v1/#{Legistar.city}/events
+  # endpoint_class: the Class of structure to create with the data retrieved from API
+  #          example: Event
+  def fetch_collection(endpoint,
                        filter,
                        prefix_to_strip,
                        endpoint_class)
-		@@endpoint = endpoint
+    @@endpoint = endpoint
     @@prefix_to_strip = prefix_to_strip
-		@@endpoint_class = endpoint_class
+    @@endpoint_class = endpoint_class
     @@url_path = "/v1/#{Legistar.city}/#{endpoint}#{filter}"
 
     log_info("fetching from endpoint: #{endpoint}, filter: #{filter}, prefix: #{prefix_to_strip}, class: #{endpoint_class}")
     go_fetch()
-	end
+  end
 
-	protected
+  protected
 
   def self.go_fetch
     begin
@@ -204,7 +204,7 @@ module Legistar
     end
   end
 
-	# collection: array of items returned from a Legistar collection endpoint
+  # collection: array of items returned from a Legistar collection endpoint
   def self.to_objects(collection)
     collection.each do |item|
       attrs = rubify_object(item, @@prefix_to_strip)
@@ -230,10 +230,10 @@ module Legistar
     end
   end
 
-	def self.log_info(msg)
+  def self.log_info(msg)
     @log.info(msg) unless Rails.env.production?
     @file_log.info(msg)
-	end
+  end
 
   def self.log_error(msg)
     @log.error(msg)

--- a/lib/legistar.rb
+++ b/lib/legistar.rb
@@ -1,4 +1,4 @@
-require 'pp'
+require "pp"
 
 module Legistar
 
@@ -13,7 +13,7 @@ module Legistar
 
   def http_response_mismatch(http_method, expected, got)
     # try to give the user somewhat human friendly responses
-    # (NET::HTTPOK is as close as we can easily get to 'HTTP OK')
+    # (NET::HTTPOK is as close as we can easily get to "HTTP OK")
     msg = "#{http_method} expected status #{expected}"\
           " (#{Net::HTTPResponse::CODE_TO_OBJ[expected.to_s]}),"\
           " but got #{got}"\
@@ -23,7 +23,7 @@ module Legistar
 
 	# hack. This should go in a config file. TODO.
 	def city
-		'Mesa'
+		"Mesa"
 	end
 
 	# set up logging and Legistar base settings
@@ -32,13 +32,13 @@ module Legistar
     @file_log = Logger.new(logfile)
     @log.level = Logger::DEBUG
     @file_log.level = Logger::DEBUG
-    @@base_url = 'http://webapi.legistar.com'
+    @@base_url = "http://webapi.legistar.com"
     # extras: any additional parameters that should be set on each object (optional)
     @@extras = nil
     @@wait = 0.5 #seconds to wait between fetching
 
 		@@connection = Faraday.new(url: @@base_url) do |conn|
-			conn.headers['Accept'] = 'text/json'
+			conn.headers["Accept"] = "text/json"
 			conn.request :instrumentation
 			conn.response :json
       conn.adapter Faraday.default_adapter
@@ -58,7 +58,7 @@ module Legistar
   # t.integer :event_id
   # t.string :event_guid
   # ...
-  # so you might want to strip off 'event':
+  # so you might want to strip off "event":
   # rake legistar_all:structure[http://webapi.legistar.com/Help/Api/GET-v1-Client-Events,"Event"]:
   # t.integer :id
   # t.string :guid
@@ -81,7 +81,7 @@ module Legistar
 
     @log.info("Connection opened to #{base_url} and logging to #{logfile}")
 
-    which_api = '4c1ec1ba-762d-421d-9da0-a399be0919d0'
+    which_api = "4c1ec1ba-762d-421d-9da0-a399be0919d0"
     query_params = {
       input: "webpage/url:#{url}",
       _apikey: "c4296b63fe04499cb43711f00cb2a72173f5caf4d1b415d217607ed5c544"\
@@ -93,7 +93,7 @@ module Legistar
     begin
       response = connection.get do |req|
         req.url query_url
-        req.headers['Content-Type'] = 'application/json'
+        req.headers["Content-Type"] = "application/json"
       end
       if response.status != 200 # Net::HTTPOK
         raise http_response_mismatch("GET", 200, response.status)
@@ -122,11 +122,11 @@ module Legistar
 	# fetches items from an endpoint nested within a nesting_endpoint.
 	# example from Legistar API:
 		# /v1/{client}/Events/{id}/EventItems
-		# endpoint is 'EventItems'
+		# endpoint is "EventItems"
 		# endpoint_filter is nil
-		# endpoint_prefix_to_strip is 'EventItem'
+		# endpoint_prefix_to_strip is "EventItem"
 		# endpoint_class is EventItem
-		# nesting_endpoint is 'Events'
+		# nesting_endpoint is "Events"
 		# nesting_class is Event
   # By default, the endpoints within every item of nesting class will be fetched;
   # the set can be overridden by passing in nesting_collection though.
@@ -138,8 +138,8 @@ module Legistar
 															nesting_class,
                               nesting_collection=nil)
 
-    @@endpoint = endpoint # 'EventItems'
-    @@prefix_to_strip = endpoint_prefix_to_strip #'EventItem'
+    @@endpoint = endpoint # "EventItems"
+    @@prefix_to_strip = endpoint_prefix_to_strip #"EventItem"
 		@@endpoint_class = endpoint_class #EventItem
 
     log_info("fetching from endpoint: #{endpoint} (nesting_endpoint: #{nesting_endpoint}), filter: #{endpoint_filter}, prefix: #{endpoint_prefix_to_strip}, class: #{endpoint_class}")
@@ -153,7 +153,7 @@ module Legistar
       # we want to keep a reference to the nesting object's id.
       # note that this is more important for Attachments, which don't
       # have an MatterId field, while EventItems do have an EventId.
-      @@extras = { nesting_class.to_s.underscore + '_id' => nesting_item.source_id}
+      @@extras = { nesting_class.to_s.underscore + "_id" => nesting_item.source_id}
 
       go_fetch()
     end
@@ -162,7 +162,7 @@ module Legistar
 
 
 	# endpoint: which endpoint in the Legistar API to fetch
-	#          example: 'events' for fetching from /v1/#{Legistar.city}/events
+	#          example: "events" for fetching from /v1/#{Legistar.city}/events
 	# endpoint_class: the Class of structure to create with the data retrieved from API
 	#          example: Event
 	def fetch_collection(endpoint,
@@ -208,17 +208,17 @@ module Legistar
   def self.to_objects(collection)
     collection.each do |item|
       attrs = rubify_object(item, @@prefix_to_strip)
-      attrs['source_id'] = attrs.delete('id')
+      attrs["source_id"] = attrs.delete("id")
       @@extras.each { |k,v| attrs[k] = v } if @@extras
 
       if @@endpoint_class == Event
         # strip EventItems from Event before creating
-        attrs.delete('items')
+        attrs.delete("items")
       end
 
       if @@endpoint_class == EventItem
         # strip MatterAttachements from EventItems before creating
-        attrs.delete('matter_attachments') # TODO? link Attachment -> EventItem?
+        attrs.delete("matter_attachments") # TODO? link Attachment -> EventItem?
       end
 
       pretty_attributes = PP.pp attrs, dump = ""
@@ -243,21 +243,21 @@ module Legistar
   # Take the structure described in the Legistar API and
   # output it in a format useful for a migration file.
   def self.print_migration(structure, prefix_to_strip)
-    # structure.results is an array of objects with 'name' and
-    # 'type' fields. Note that the name will be in PascalCase,
+    # structure.results is an array of objects with "name" and
+    # "type" fields. Note that the name will be in PascalCase,
     # not snake_case. It will also have the RestEndpointName
     # prepended to each.
     # We need to convert that into lines like: t.integer :source_id
-    structure['results'].each do |field|
-      puts 't.' + rubify_type(field['type']) + ' :' + rubify_name(field['name'], prefix_to_strip)
+    structure["results"].each do |field|
+      puts "t." + rubify_type(field["type"]) + " :" + rubify_name(field["name"], prefix_to_strip)
     end
   end
 
   # convert types from Legistar documentation to ruby appropriate types
   def self.rubify_type(type)
     case type
-    when 'Collection of byte' then 'string'
-    when 'date' then 'datetime'
+    when "Collection of byte" then "string"
+    when "date" then "datetime"
     else type
     end
   end
@@ -266,11 +266,11 @@ module Legistar
   # to ruby format.
   # camelcase_object: just SomeObject object which needs to have
   #       SomeObjectPropertyNames changed to property_names
-  # prefix_to_strip: any CamelCase part like 'SomeObject' which should be
+  # prefix_to_strip: any CamelCase part like "SomeObject" which should be
   #        removed before converting the rest of the name to snake_case
   # Example:
-  # camel = { 'CamelFirstName' => 'Ed', 'CamelLastName' => 'Jones' }
-  # rubify_object(camel, 'Camel')
+  # camel = { "CamelFirstName" => "Ed", "CamelLastName" => "Jones" }
+  # rubify_object(camel, "Camel")
   # => {"first_name"=>"Ed", "last_name"=>"Jones"}
   #
   def self.rubify_object(camelcase_object, prefix_to_strip)
@@ -281,9 +281,9 @@ module Legistar
   end
 
   # Convert prefixed PascalCase to snake_case, sans prefix
-  # ex: rubyify_name('PrefixedFieldName', 'Prefixed') => 'field_name'
+  # ex: rubyify_name("PrefixedFieldName", "Prefixed") => "field_name"
   def self.rubify_name(camelcase_name, prefix_to_strip)
-    camelcase_name.sub(prefix_to_strip, '').underscore
+    camelcase_name.sub(prefix_to_strip, "").underscore
   end
 
 

--- a/lib/legistar.rb
+++ b/lib/legistar.rb
@@ -211,6 +211,16 @@ module Legistar
 		  attrs['source_id'] = attrs.delete('id')
       @@extras.each { |k,v| attrs[k] = v } if @@extras
 
+      if @@endpoint_class == Event
+        # strip EventItems from Event before creating
+        attrs.delete('items')
+      end
+
+      if @@endpoint_class == EventItem
+        # strip MatterAttachements from EventItems before creating
+        attrs.delete('matter_attachments') # TODO? link Attachment -> EventItem?
+      end
+
 		  pretty_attributes = PP.pp attrs, dump = ""
 		  msg = "Attempting creation of #{@@endpoint_class.to_s} with attrs: #{pretty_attributes}"
 		  log_info(msg)

--- a/lib/legistar.rb
+++ b/lib/legistar.rb
@@ -206,9 +206,9 @@ module Legistar
 
 	# collection: array of items returned from a Legistar collection endpoint
   def self.to_objects(collection)
-		collection.each do |item|
-		  attrs = rubify_object(item, @@prefix_to_strip)
-		  attrs['source_id'] = attrs.delete('id')
+    collection.each do |item|
+      attrs = rubify_object(item, @@prefix_to_strip)
+      attrs['source_id'] = attrs.delete('id')
       @@extras.each { |k,v| attrs[k] = v } if @@extras
 
       if @@endpoint_class == Event
@@ -221,13 +221,14 @@ module Legistar
         attrs.delete('matter_attachments') # TODO? link Attachment -> EventItem?
       end
 
-		  pretty_attributes = PP.pp attrs, dump = ""
-		  msg = "Attempting creation of #{@@endpoint_class.to_s} with attrs: #{pretty_attributes}"
-		  log_info(msg)
+      pretty_attributes = PP.pp attrs, dump = ""
+      msg = "Attempting creation of #{@@endpoint_class.to_s} "\
+            "with attrs: #{pretty_attributes}"
+      log_info(msg)
 
-		  @@endpoint_class.find_or_create_by(attrs)
-		end
-	end
+      @@endpoint_class.find_or_create_by(attrs)
+    end
+  end
 
 	def self.log_info(msg)
     @log.info(msg) unless Rails.env.production?

--- a/lib/tasks/legistar_all.rake
+++ b/lib/tasks/legistar_all.rake
@@ -1,4 +1,4 @@
-require 'legistar'
+require "legistar"
 
 namespace :legistar_all do
   desc "Wipe our database, then rebuild it by recopying content via Legistar API"
@@ -25,6 +25,6 @@ namespace :legistar_all do
   end
 
   desc "Display Legistar stats (number of items in each database table)"
-  task :stats => ['legistar_stats:print'] do
+  task :stats => ["legistar_stats:print"] do
   end
 end

--- a/lib/tasks/legistar_all.rake
+++ b/lib/tasks/legistar_all.rake
@@ -23,4 +23,8 @@ namespace :legistar_all do
   task :structure, [:url, :prefix_to_strip] => [:environment] do |t, args|
     Legistar.fetch_structure(args.url, args.prefix_to_strip)
   end
+
+  desc "Display Legistar stats (number of items in each database table)"
+  task :stats => ['legistar_stats:print'] do
+  end
 end

--- a/lib/tasks/legistar_stats.rake
+++ b/lib/tasks/legistar_stats.rake
@@ -1,0 +1,24 @@
+require 'legistar'
+
+namespace :legistar_stats do
+  desc "Display Legistar stats (number of items in each database table)"
+  task :print => :environment do
+
+    dev_null = Logger.new("/dev/null")
+    # Rails.logger = dev_null
+    ActiveRecord::Base.logger = dev_null
+    # Log to /dev/null to get rid of database output like
+    # (0.6ms)  SELECT COUNT(*) FROM "matter_attachments"
+    # http://stackoverflow.com/a/5783955/1024811
+
+    models = [CouncilDistrict, Matter, MatterAttachment, Event, EventItem]
+    total = 0
+    models.each do |model|
+      count = model.count
+      total += count
+      puts "#{model.name}: #{count}"
+    end
+
+    puts "Total databases rows: #{total}"
+  end
+end

--- a/lib/tasks/legistar_stats.rake
+++ b/lib/tasks/legistar_stats.rake
@@ -1,9 +1,8 @@
-require 'legistar'
+require "legistar"
 
 namespace :legistar_stats do
   desc "Display Legistar stats (number of items in each database table)"
   task :print => :environment do
-
     dev_null = Logger.new("/dev/null")
     # Rails.logger = dev_null
     ActiveRecord::Base.logger = dev_null


### PR DESCRIPTION
Now after `rake legistar_all:load` or

```
rake legistar_events:load 
rake legistar_event_items:load
# (Assuming we'd run rake legistar_all:load prior to this fix, 
# and had already fetched Matters and MatterAttachments)
```

we have Events and EventItems:
```
rake legistar_all:stats
CouncilDistrict: 0
Matter: 392
MatterAttachment: 1086
Event: 56
EventItem: 852
Total databases rows: 2386
```